### PR TITLE
Set WORKDIR in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ RUN useradd -ms /bin/bash wiremock
 
 USER wiremock
 
+WORKDIR /home/wiremock
+
 RUN  curl -L "https://github.com/holomekc/wiremock/releases/download/2.27.2-ui/wiremock-standalone-2.27.2.jar" -o /home/wiremock/wiremock.jar
 
 CMD java -XX:+PrintFlagsFinal $JAVA_OPTIONS -jar /home/wiremock/wiremock.jar


### PR DESCRIPTION
Hi @holomekc!

With the default wiremock settings, the webapp gives a HTTP 400 Bad Request response when using the recording feature, since the `/mappings` directory cannot be created.

Setting the WORKDIR enables the container to create a `/home/wiremock/mappings` directory, and the webapp's recording feature works then.

I wasn't sure whether you are considering pull requests for this project, and I didn't touch the project version.

Thanks,
Matt