### PR TITLE
Please rebuild docker image from openjdk:8 upstream to resolve CVE

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,4 @@ Images
 [Separated View](./images/mappings-separated.png)
 
 [StateMachine](./images/state-machine.png)
+


### PR DESCRIPTION
Hello @holomekc ,

I apologize that I cannot create an issue to request this, please close this PR when appropriate. 

Can you please rebuild and push `holomekc/wiremock-gui:2.27.2.1` and/or `holomekc/wiremock-gui:latest` to Dockerhub to resolve a critical vulnerability found in the openjdk:8 upstream image?

```
Image                                                                      CVE               Package    Version    Severity    Status
-----                                                                      ---               -------    -------    --------    ------
sha256:a397468f5e352e58f6d5c9eea1e9c4cdd97130540cd8713ccd17c0e38a6f55e3    CVE-2019-20367    libbsd     0.9.1-2    critical    fixed in 0.9.1-2+deb10u1: unknown
```

Thank you!