### PR TITLE
Bumping Handlebars library version to 4.3.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ group = 'com.github.tomakehurst'
 
 project.ext {
   versions = [
-    handlebars     : '4.3.0',
+    handlebars     : '4.3.1',
     jetty          : '9.4.48.v20220622',
     guava          : '31.1-jre',
     jackson        : '2.13.4',


### PR DESCRIPTION
This is in response to https://github.com/wiremock/wiremock/issues/1990 .